### PR TITLE
fix(android): force DashMediaSource for .lds URIs

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/player/MediaSourceUtils.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/player/MediaSourceUtils.kt
@@ -28,7 +28,16 @@ fun buildMediaSource(context: Context, source: HybridVideoPlayerSource, mediaIte
   // Explanation:
   // 1. Remove query params from uri to avoid getting false extension
   // 2. Get extension from uri
-  val type = Util.inferContentType(uri)
+  //
+  // Learnyst: ".lds" is the V6 server's offline DASH manifest extension. ExoPlayer's
+  // Util.inferContentType would return CONTENT_TYPE_OTHER and fall through to the
+  // progressive extractors, which can't read the DASH bytes. Force DASH for .lds URIs.
+  val rawType = Util.inferContentType(uri)
+  val type = if (rawType == C.CONTENT_TYPE_OTHER && uri.path?.endsWith(".lds") == true) {
+    C.CONTENT_TYPE_DASH
+  } else {
+    rawType
+  }
   val dataSourceFactory = PluginsRegistry.shared.overrideMediaDataSourceFactory(
     source,
     buildBaseDataSourceFactory(context, source)


### PR DESCRIPTION
Learnyst V6 saves offline DASH manifests with the ".lds" extension (server-side OfflineDash_*.lds naming). ExoPlayer's Util.inferContentType returns CONTENT_TYPE_OTHER for unknown extensions, falling through to the progressive extractors which can't parse the DASH bytes — playback fails with UnrecognizedInputFormatException on offline .lds content.

Override the inferred type when the URI path ends in ".lds" so the DashMediaSource.Factory branch handles it. .mpd and .m3u8 URIs are unaffected (inferContentType already returns the right value).